### PR TITLE
added cron config for travis ping

### DIFF
--- a/cron_job/metadata.rb
+++ b/cron_job/metadata.rb
@@ -1,0 +1,6 @@
+name             'cron_job'
+maintainer       'AbleTech'
+maintainer_email 'info@abletech.nz'
+license          'All rights reserved'
+description      'Configures arbitrary cron jobs'
+version          '0.1.0'

--- a/cron_job/recipes/default.rb
+++ b/cron_job/recipes/default.rb
@@ -1,0 +1,5 @@
+cron "ping_travis_ci" do
+  hour "22"
+  minute "0"
+  command "cd /path_to_app && node ping.js"
+end


### PR DESCRIPTION
This is the was Amazon suggests that cron jobs are added to an opsworks stack. http://docs.aws.amazon.com/opsworks/latest/userguide/workingcookbook-extend-cron.html
What do you think @marcusbaguley ?
